### PR TITLE
Disabling the generation of the bogus testfile

### DIFF
--- a/lib/Dist/Zilla/Plugin/TaskWeaver.pm
+++ b/lib/Dist/Zilla/Plugin/TaskWeaver.pm
@@ -115,7 +115,7 @@ sub gather_files {
     Dist::Zilla::File::InMemory->new({
       name    => 't/task-bogus.t',
       content => <<'END_TEST',
-use strict;
+use strict; use warnings;
 use Test::More tests => 1;
 ok(1, 'tasks need no tests, but CPAN clients demand them');
 END_TEST


### PR DESCRIPTION
This is a minor PR to add a new attribute so I can control whether it is added or not. In my case I already generated other testfiles so it was unnecessary for me. To add insult to injury, Test::Strict's warnings check also flagged the file as failing... The second commit fixes that :)
