### PR TITLE
fix config_plugins

### DIFF
--- a/lib/Dist/Zilla/Plugin/TaskWeaver.pm
+++ b/lib/Dist/Zilla/Plugin/TaskWeaver.pm
@@ -57,6 +57,20 @@ modern ExtUtils::MakeMaker, probably v6.68 or later.  You can do that with:
 use Moose::Autobox;
 use Pod::Weaver::Plugin::TaskWeaver;
 
+# this is weird because it is *supposed* to work via extending PodWeaver!
+sub mvp_aliases { return { config_plugin => 'config_plugins' } }
+sub mvp_multivalue_args { qw(config_plugins) }
+
+has config_plugins => (
+  isa => 'ArrayRef[Str]',
+  traits  => [ 'Array' ],
+  default => sub {  []  },
+  handles => {
+    config_plugins     => 'elements',
+    has_config_plugins => 'count',
+  },
+);
+
 # need an attr for "plugin name to put this after" -- ugh! -- or a coderef to
 # find the first plugin where the coderef tests true; useful for "generic and
 # selector name is synopsis" or something -- rjbs, 2009-11-28


### PR DESCRIPTION
I finally released a dist using TaskWeaver, yay! However, I was dismayed to see that my fancy PodWeaver setup wasn't working at all when I built the dist. After digging around I saw that TaskWeaver extended PodWeaver so in theory it should have been calling my config_plugins bundle. I tried to debug but got lost in the guts of CMOP so I gave up. The fix is simple so this is puzzling! Thanks again for looking into this :)
